### PR TITLE
Set up UI components for YouTube talk links and embedded recordings

### DIFF
--- a/_layouts/speaker.html
+++ b/_layouts/speaker.html
@@ -75,6 +75,42 @@ layout: application_speaker
         </div>
       </div>
     </div>
+
+<!--      Link to YT-->
+      {% if page.recording %}
+      <div class="mt-4">
+          <div class="card shadow-sm border-0">
+              <div class="card-body text-center">
+                  <h5 class="card-title text-info-emphasis mb-3">
+                      🎥 Watch {{ page.title }}’s Talk
+                  </h5>
+                  <a href="{{ page.recording }}" target="_blank" class="btn btn-danger btn-lg d-inline-flex align-items-center gap-2">
+                      <i class="fab fa-youtube fs-4"></i> Watch on YouTube
+                  </a>
+              </div>
+          </div>
+      </div>
+      {% endif %}
+ <!--      Embed recording-->
+      {% if page.recording %}
+      <div class="mt-4">
+          <div class="card shadow-sm border-0">
+              <div class="card-body">
+                  <h5 class="card-title text-info-emphasis mb-3 text-center">
+                      🎥 Recording of {{ page.title }}’s Talk
+                  </h5>
+                  <div class="ratio ratio-16x9">
+                      <iframe src="{{ page.recording | replace: 'watch?v=', 'embed/' }}"
+                              title="YouTube video"
+                              allowfullscreen>
+                      </iframe>
+                  </div>
+              </div>
+          </div>
+      </div>
+      {% endif %}
+
+
   </div>
 </section>
 <!--End Speaker Detail -->

--- a/schedule.html
+++ b/schedule.html
@@ -85,7 +85,14 @@ image: "/images/logo/arc_logo_coloured.png"
                           style="width: 60px; height: 60px"
                         />
                       </a>
-                      <span class="text-dark small">{{ speaker_trimmed }}</span>
+                      <span class="text-dark small d-flex align-items-center gap-2">
+                          {{ speaker_trimmed }}
+                          {% if event.recording and event.recording != "" %}
+                            <a href="{{ event.recording }}" target="_blank" class="ms-1">
+                                <i class="fab fa-youtube fs-3 text-danger" ></i>
+                            </a>
+                          {% endif %}
+                      </span>
                     </figure>
                     {% endfor %}
                   </div>


### PR DESCRIPTION
This pull request includes the following changes:
- Set up placeholders for YouTube links in speaker talk sections.
- Added embedded video components to schedule events for future recordings.